### PR TITLE
fix: logging reduction with better exception handling

### DIFF
--- a/adscompstat/bibcodes.py
+++ b/adscompstat/bibcodes.py
@@ -72,7 +72,7 @@ class BibcodeGenerator(object):
             page = page.replace(',', '')
             return page
         else:
-            return None
+            return '.'
 
     def _deletter_page(self, page):
         is_letter = None

--- a/adscompstat/bibcodes.py
+++ b/adscompstat/bibcodes.py
@@ -45,7 +45,7 @@ class BibcodeGenerator(object):
             volume = record['publication']['volumeNum']
             volume = volume
         except Exception as err:
-            volume = None
+            volume = '.'
         return volume
 
     def _get_issue(self, record):
@@ -68,7 +68,7 @@ class BibcodeGenerator(object):
             elif rpage:
                 page = rpage
             else:
-                page = None
+                page = '.'
             page = page.replace(',', '')
             return page
         else:

--- a/adscompstat/exceptions.py
+++ b/adscompstat/exceptions.py
@@ -22,6 +22,10 @@ class CrossRefParseException(Exception):
     pass
 
 
+class BaseParseException(Exception):
+    pass
+
+
 class LoadClassicDataException(Exception):
     pass
 

--- a/adscompstat/exceptions.py
+++ b/adscompstat/exceptions.py
@@ -26,6 +26,10 @@ class BaseParseException(Exception):
     pass
 
 
+class EmptyRecordException(Exception):
+    pass
+
+
 class LoadClassicDataException(Exception):
     pass
 

--- a/adscompstat/match.py
+++ b/adscompstat/match.py
@@ -42,7 +42,7 @@ class CrossrefMatcher(object):
                     errs['init'] = classicInit
                 returnDict['errs'] = errs
             else:
-                returnDict['match'] = 'Mismatched'
+                returnDict['match'] = 'Mismatch'
                 returnDict['errs'] = {'bibcode': classicBibcode}
         except Exception as err:
             return

--- a/adscompstat/tasks.py
+++ b/adscompstat/tasks.py
@@ -48,7 +48,7 @@ def task_write_result_to_db(inrec):
                 session.add(outrec)
                 session.commit()
             else:
-                logger.info("Record for DOI %s exists already, ignoring for now." % checkdoi)
+                logger.debug("Record for DOI %s exists already, ignoring for now." % checkdoi)
         except Exception as err:
             session.rollback()
             session.flush()

--- a/adscompstat/tasks.py
+++ b/adscompstat/tasks.py
@@ -34,16 +34,21 @@ except Exception as err:
 def task_write_result_to_db(inrec):
     with app.session_scope() as session:
         try:
-            outrec = master(harvest_filepath=inrec[0],
-                            master_doi=inrec[1],
-                            issns=inrec[2],
-                            db_origin='Crossref',
-                            master_bibdata=inrec[3],
-                            classic_match=inrec[4],
-                            status=inrec[5],
-                            matchtype=inrec[6])
-            session.add(outrec)
-            session.commit()
+            checkdoi = inrec[1]
+            result = session.query(master).filter(master_doi==checkdoi).all()
+            if not result:
+                outrec = master(harvest_filepath=inrec[0],
+                                master_doi=inrec[1],
+                                issns=inrec[2],
+                                db_origin='Crossref',
+                                master_bibdata=inrec[3],
+                                classic_match=inrec[4],
+                                status=inrec[5],
+                                matchtype=inrec[6])
+                session.add(outrec)
+                session.commit()
+            else:
+                logger.info("Record for DOI %s exists already, ignoring for now." % checkdoi)
         except Exception as err:
             session.rollback()
             session.flush()

--- a/adscompstat/tasks.py
+++ b/adscompstat/tasks.py
@@ -121,7 +121,11 @@ def task_process_metafile(infile):
         if first_author:
             first_author = first_author[0]
     except Exception as err:
-        logger.warning("Unable to process metafile %s: %s" % (infile, err))
+        logger.info("Unable to process metafile %s, logging without bibdata" % infile)
+        try:
+            task_
+#ADD ME
+        # task_write_result_to_db({DOI, filename, 'NotIndexed'})
     else:
         bib_data = {'publication': publication,
                    'pagination': pagination,

--- a/adscompstat/tasks.py
+++ b/adscompstat/tasks.py
@@ -35,7 +35,7 @@ def task_write_result_to_db(inrec):
     with app.session_scope() as session:
         try:
             checkdoi = inrec[1]
-            result = session.query(master).filter(master_doi==checkdoi).all()
+            result = session.query(master.master_doi).filter_by(master_doi=checkdoi).all()
             if not result:
                 outrec = master(harvest_filepath=inrec[0],
                                 master_doi=inrec[1],

--- a/adscompstat/tasks.py
+++ b/adscompstat/tasks.py
@@ -54,6 +54,7 @@ def task_match_record_to_classic(processingRecord):
     allowedMatchType = ['Exact', 'Deleted', 'Alternate', 'Partial', 'Other']
     try:
         if processingRecord.get('record', None) == '':
+            harvest_filepath = processingRecord.get('harvest_filepath', None)
             status = 'NoIndex'
             matchtype = 'Other'
             classic_match = {}
@@ -70,18 +71,18 @@ def task_match_record_to_classic(processingRecord):
             if matchtype == 'Classic Canonical Bibcode':
                 matchtype = 'Other'
             classic_match = xmatchResult.get('errs', {})
-        if type(classic_match) == dict:
-            classic_match = json.dumps(classic_match)
-        issns = processingRecord.get('issns', {})
-        if type(issns) == dict:
-            issns = json.dumps(issns)
-        master_bibdata = processingRecord.get('master_bibdata', {})
-        if type(master_bibdata) == dict:
-            master_bibdata = json.dumps(master_bibdata)
     except Exception as err:
         logger.warning("Error matching record: %s" % err)
     else:
         try:
+            if type(classic_match) == dict:
+                classic_match = json.dumps(classic_match)
+            issns = processingRecord.get('issns', {})
+            if type(issns) == dict:
+                issns = json.dumps(issns)
+            master_bibdata = processingRecord.get('master_bibdata', {})
+            if type(master_bibdata) == dict:
+                master_bibdata = json.dumps(master_bibdata)
             outputRecord = (harvest_filepath,
                             master_doi,
                             issns,
@@ -99,7 +100,7 @@ def task_add_bibcode(processingRecord):
         record = processingRecord.get('record', None)
         bibcode = bibgen.make_bibcode(record)
     except Exception as err:
-        logger.info("Failed to create bibcode: %s" % err)
+        logger.debug("Failed to create bibcode: %s" % err)
         bibcode = None
     processingRecord['bibcode'] = bibcode
     task_match_record_to_classic.delay(processingRecord)

--- a/adscompstat/tasks.py
+++ b/adscompstat/tasks.py
@@ -55,6 +55,7 @@ def task_match_record_to_classic(processingRecord):
     try:
         if processingRecord.get('record', None) == '':
             harvest_filepath = processingRecord.get('harvest_filepath', None)
+            master_doi = processingRecord.get('master_doi', None)
             status = 'NoIndex'
             matchtype = 'Other'
             classic_match = {}

--- a/adscompstat/tasks.py
+++ b/adscompstat/tasks.py
@@ -115,6 +115,8 @@ def task_add_empty_record(infile):
                             'issns': json.dumps(issns),
                             'master_bibdata': json.dumps(bib_data)}
         task_add_bibcode.delay(processingRecord)
+    except Exception as err:
+        raise EmptyRecordException(err)
 
 @app.task(queue='parse-meta')
 def task_process_metafile(infile):

--- a/adscompstat/tasks.py
+++ b/adscompstat/tasks.py
@@ -94,7 +94,7 @@ def task_add_bibcode(processingRecord):
         record = processingRecord.get('record', None)
         bibcode = bibgen.make_bibcode(record)
     except Exception as err:
-        logger.warn("Failed to create bibcode for file %s: %s" % (sourceFile, err))
+        logger.warn("Failed to create bibcode: %s" % err)
         bibcode = None
     processingRecord['bibcode'] = bibcode
     task_match_record_to_classic.delay(processingRecord)

--- a/adscompstat/utils.py
+++ b/adscompstat/utils.py
@@ -61,15 +61,27 @@ def parse_one_meta_xml(filename):
 
 
 def simple_parse_one_meta_xml(filename):
+'''
+This just returns the DOI and ISSNs from the file.
+'''
     try:
         with open(filename,'r') as fx:
             data = fx.read()
             try:
                 parser = BaseBeautifulSoupParser()
                 record = parser.bsstrtodict(data)
+                doi = record.find("doi").get_text()
+                issn_all = record.find_all("issn")
+                issns = []
+                for i in issn_all:
+                    if i.get_text() and re_issn.match(i.get_text()):
+                        if i.has_attr("media_type"):
+                            issns.append((i["media_type"], i.get_text()))
+                        else:
+                            issns.append(("print", i.get_text()))
             except Exception as err:
                 raise BaseParseException(err)
-        return record
+        return (doi, issns)
     except Exception as err:
         raise ParseMetaXMLException(err)
 

--- a/adscompstat/utils.py
+++ b/adscompstat/utils.py
@@ -61,9 +61,6 @@ def parse_one_meta_xml(filename):
 
 
 def simple_parse_one_meta_xml(filename):
-'''
-This just returns the DOI and ISSNs from the file.
-'''
     try:
         with open(filename,'r') as fx:
             data = fx.read()

--- a/adscompstat/utils.py
+++ b/adscompstat/utils.py
@@ -1,5 +1,7 @@
+from bs4 import BeautifulSoup
 from adscompstat.exceptions import *
 from adsingestp.parsers.crossref import CrossrefParser
+from adsingestp.parsers.base import BaseBeautifulSoupParser
 from glob import glob
 
 
@@ -53,6 +55,20 @@ def parse_one_meta_xml(filename):
                 record = parser.parse(data)
             except Exception as err:
                 raise CrossRefParseException(err)
+        return record
+    except Exception as err:
+        raise ParseMetaXMLException(err)
+
+
+def simple_parse_one_meta_xml(filename):
+    try:
+        with open(filename,'r') as fx:
+            data = fx.read()
+            try:
+                parser = BaseBeautifulSoupParser()
+                record = parser.bsstrtodict(data)
+            except Exception as err:
+                raise BaseParseException(err)
         return record
     except Exception as err:
         raise ParseMetaXMLException(err)

--- a/adscompstat/utils.py
+++ b/adscompstat/utils.py
@@ -1,8 +1,11 @@
+import re
 from bs4 import BeautifulSoup
 from adscompstat.exceptions import *
 from adsingestp.parsers.crossref import CrossrefParser
 from adsingestp.parsers.base import BaseBeautifulSoupParser
 from glob import glob
+
+re_issn = re.compile(r"^\d{4}-?\d{3}[0-9X]$")
 
 
 def get_updateagent_logs(logdir):


### PR DESCRIPTION
Better handing of edge cases; check existing DOI before attempting to write to db; unparseable records still get a db entry (doi, issn(s), and filename); issue logger.info/.warning when record cannot be written to db, otherwise use .debug